### PR TITLE
イベントタイトルの特殊文字の表示修正

### DIFF
--- a/src/components/liveItem.tsx
+++ b/src/components/liveItem.tsx
@@ -53,7 +53,7 @@ const Index = ({ isDetail, data }) => {
           <MetaDateTimeStart>START {startDate}</MetaDateTimeStart>
         </MetaDateTime>
       </Meta>
-      {!isDetail ? <Title>{data.title}</Title> : null}
+      {!isDetail ? <Title dangerouslySetInnerHTML={{ __html: data.title }} /> : null}
       <Adv isDetail={isDetail}>
         <AdvHeadline>Ticket info</AdvHeadline>
         <AdvContent dangerouslySetInnerHTML={{ __html: data.acf.adv }} />

--- a/src/templates/PostTemplate.tsx
+++ b/src/templates/PostTemplate.tsx
@@ -17,7 +17,7 @@ export default ({ data, pageContext, path }) => {
   return (
     <Layout>
       <SEO title={data.wordpressPost.title} />
-      <Headline>{data.wordpressPost.title}</Headline>
+      <Headline dangerouslySetInnerHTML={{ __html: data.wordpressPost.title }} />
       <LiveItemWrapper>
         <LiveItem data={data.wordpressPost} isDetail></LiveItem>
       </LiveItemWrapper>


### PR DESCRIPTION
dangerouslySetInnerHTML をliveitem.tsxとPostTemplate.tsxに記載し、#10 を修正しました。