### PR TITLE
Fix #18 generation process of schedule page

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -92,8 +92,14 @@ exports.createPages = async ({ graphql, actions }) => {
   const max = Math.max(...YYYYMMs);
   let schedulesArray = [];
 
+  // min から max までの値 (YYYY/MM/DD) のスケジュールページを生成。
+  // 実在しない月 (下2桁が 00 もしくは 13 以上) であれば処理をスキップする。
+  // TODO: とても実装がイマイチなので、後で直したい
   for (let i = min; i <= max; i++) {
-    schedulesArray.push(i);
+    const numStr = parseInt(i.toString().slice(-2), 10);
+    if (numStr >= 1 && numStr <= 12) {
+      schedulesArray.push(i);
+    }
   }
 
   function generatePath(YYYYMM) {


### PR DESCRIPTION
スケジュールページ生成処理に未考慮な部分があり、本来不要なページが生成され、ページネーションがそこへリンクを張ってしまっていた事が原因。

該当箇所を修正し対応しました。
(やや強引な方法を取っているので、もっとスマートな処理へ後々修正したいです。)