### PR TITLE
情報の削除と追加

### DIFF
--- a/src/components/footer.jsx
+++ b/src/components/footer.jsx
@@ -20,16 +20,7 @@ export default () => {
         </SiteInfoLogo>
         <Menu>
           <li>
-            <Link to={`/schedule/${thisMonth}`}>Schedule</Link>
-          </li>
-          <li>
             <Link to="/about">About</Link>
-          </li>
-          <li>
-            <Link to="/access">Access</Link>
-          </li>
-          <li>
-            <Link to="/system">System</Link>
           </li>
           <li>
             <Link to="/contact">Contact</Link>
@@ -37,13 +28,6 @@ export default () => {
         </Menu>
         <SiteInfoAddress>
           <p>
-            沖縄県宜野湾市長田1-11-1
-            <br />
-            〒901-2212
-          </p>
-          <p>
-            TEL : 098-893-3060
-            <br />
             Mail : human-s@nirai.ne.jp
           </p>
         </SiteInfoAddress>

--- a/src/components/nav.tsx
+++ b/src/components/nav.tsx
@@ -28,16 +28,7 @@ export default (props: Props) => {
       </Link>
       <Menu>
         <li>
-          <Link to={`/schedule/${props.lastSchedule}`}>Schedule</Link>
-        </li>
-        <li>
           <Link to="/about">About</Link>
-        </li>
-        <li>
-          <Link to="/access">Access</Link>
-        </li>
-        <li>
-          <Link to="/system">System</Link>
         </li>
         <li>
           <Link to="/contact">Contact</Link>
@@ -91,23 +82,8 @@ export default (props: Props) => {
       >
         <DrawerManu>
           <li>
-            <Link to={`/schedule/${props.lastSchedule}`}>
-              <a>Schedule</a>
-            </Link>
-          </li>
-          <li>
             <Link to="/about">
               <a>About</a>
-            </Link>
-          </li>
-          <li>
-            <Link to="/access">
-              <a>Access</a>
-            </Link>
-          </li>
-          <li>
-            <Link to="/system">
-              <a>System</a>
             </Link>
           </li>
           <li>
@@ -117,9 +93,6 @@ export default (props: Props) => {
           </li>
         </DrawerManu>
       </Drawer>
-      <InfoBar>
-        <a href="https://twitter.com/HumanStage/status/1270614616658202624?" target="_blank">ヒューマンステージからのお知らせ</a>
-      </InfoBar>
     </AppBar>
   );
 };
@@ -260,24 +233,6 @@ const DrawerManu = styled.ul`
       &:hover {
         text-decoration: underline;
       }
-    }
-  }
-`;
-
-const InfoBar = styled.div`
-  width: 100%;
-  height: 35px;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  border-top: 1px solid #ddd;
-  padding: .5em 0;
-  box-sizing: border-box;
-  font-size: 1rem;
-  a {
-    color: #188fd9;
-    &:hover {
-      text-decoration: none;
     }
   }
 `;

--- a/src/templates/TopPageTemplate.tsx
+++ b/src/templates/TopPageTemplate.tsx
@@ -30,15 +30,6 @@ export default ({ data, pageContext }) => {
       <BaseLink>
         <a href="https://humanstage.thebase.in/" target="_blank"><img src={baseImg} alt="Human Stage 応援サイト" /></a>
       </BaseLink>
-      <Headline>Upcoming Events</Headline>
-      <LiveItemsWrapper>
-        <LiveItems data={data} />
-      </LiveItemsWrapper>
-      <ButtonWrapper>
-        <Link to={`/schedule/${pageContext.lastSchedule}`}>
-          <Button>More Schedule</Button>
-        </Link>
-      </ButtonWrapper>
     </Layout>
   );
 };

--- a/src/templates/TopPageTemplate.tsx
+++ b/src/templates/TopPageTemplate.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import styled from 'styled-components';
 import { Link, graphql } from 'gatsby';
+import Helmet from 'react-helmet';
 import LiveItems from '../components/liveItems';
 
 import Layout from '../components/layout';
@@ -13,6 +14,16 @@ export default ({ data, pageContext }) => {
   return (
     <Layout lastSchedule={pageContext.lastSchedule}>
       <SEO title="" />
+
+      { /* Tweet 埋め込みようの script */}
+      <Helmet>
+        <script async src="https://platform.twitter.com/widgets.js" charSet="utf-8" />
+      </Helmet>
+
+      <TwitterCard>
+        <blockquote className="twitter-tweet"><p lang="ja" dir="ltr">ヒューマンステージからのお知らせ！ <a href="https://t.co/FLdCFA4Sdj">pic.twitter.com/FLdCFA4Sdj</a></p>&mdash; 山田さん (@HumanStage) <a href="https://twitter.com/HumanStage/status/1270614616658202624?ref_src=twsrc%5Etfw">June 10, 2020</a></blockquote>
+      </TwitterCard>
+
       <CampfireLink>
         <a href="https://camp-fire.jp/projects/view/298923" target="_blank"><img src={campfireImg} alt="宜野湾HUMAN STAGE支援プロジェクト〜NEXT HUMAN STAGE〜" /></a>
       </CampfireLink>
@@ -120,5 +131,14 @@ const CampfireLink = styled.p`
   img {
     width: 100%;
     height: auto;
+  }
+`;
+
+const TwitterCard = styled.div`
+  margin: 0 auto 1.5rem;
+  width: calc(100% - 30px);
+
+  > .twitter-tweet {
+    margin: 0 auto;
   }
 `;


### PR DESCRIPTION
- ライブハウスの閉店にあたり不要となった情報とページへのリンクを削除。
- ヘッダーへ設置していた閉店情報へのリンクが少し分かりづらいとのご指摘を頂き、トップへツイートをそのまま埋め込む形へ変更

Ref: #26 