### PR TITLE
環境変数をクライアントサイドのJSで利用できるよう修正

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -41,7 +41,7 @@ module.exports = {
     {
       resolve: `gatsby-source-wordpress-experimental`,
       options: {
-        url: `https://${process.env.WP_BASE_URL}/graphql`,
+        url: `https://${process.env.GATSBY_WP_BASE_URL}/graphql`,
         verbose: true,
         develop: {
           hardCacheMediaFiles: true,
@@ -56,15 +56,15 @@ module.exports = {
             limit:
               process.env.NODE_ENV === `development`
                 ? // Lets just pull 50 posts in development to make it easy on ourselves.
-                50
+                  50
                 : // and we don't actually need more than 5000 in production for this particular site
-                5000,
+                  5000,
           },
         },
         plugins: [
           {
             resolve: `gatsby-wordpress-experimental-inline-images`,
-          }
+          },
         ],
       },
     },

--- a/src/lib/apollo-client.ts
+++ b/src/lib/apollo-client.ts
@@ -2,7 +2,7 @@ import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client';
 
 const cache = new InMemoryCache();
 const link = new HttpLink({
-  uri: `https://${process.env.WP_BASE_URL}/graphql`,
+  uri: `https://${process.env.GATSBY_WP_BASE_URL}/graphql`,
   credentials: 'include',
 });
 


### PR DESCRIPTION
先の修正ではうまくプレビューが動作せず、その原因を調査したところ WP の管理画面の URL の環境変数がクライアントサイドの JS で undefined となっていました。
[どうやら Gatsby にてフロントの JS で環境変数を利用する場合は命名を GATSBY_ から始めないといけない](https://www.gatsbyjs.com/docs/environment-variables/#client-side-javascript)ようで、そのように修正しました。(きちんと理解していなかった…)